### PR TITLE
Changed git command

### DIFF
--- a/build_and_upload.sh
+++ b/build_and_upload.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-version=$(git describe --tags)
+version=$(git describe --tags --abbrev=0)
 poetry version "${version}"
 poetry build $INPUT_POETRY_BUILD_ARGS
 TWINE_USERNAME="$INPUT_PYPI_USERNAME" TWINE_PASSWORD="$INPUT_PYPI_PASSWORD" twine upload $INPUT_TWINE_UPLOAD_ARGS dist/*


### PR DESCRIPTION
"--abbrev=0" returns the closest annotated tag, making it possible to manually call for a new publish with i.e a manual dispatch from Github Actions, instead of being forced to use "on push".